### PR TITLE
session fixation attack protection

### DIFF
--- a/lib/Plack/Middleware/Auth/Form.pm
+++ b/lib/Plack/Middleware/Auth/Form.pm
@@ -71,6 +71,7 @@ sub _login {
             $user_id = $params->get( 'username' );
         }
         if( !$login_error ){
+            $env->{'psgix.session.options'}->{change_id}++;
             $env->{'psgix.session'}{user_id} = $user_id;
             $env->{'psgix.session'}{remember} = 1 if $params->get( 'remember' );
             my $redir_to = delete $env->{'psgix.session'}{redir_to};


### PR DESCRIPTION
added 'change_id' option for session fixation attack protection from P::M::Session 0.13.
